### PR TITLE
Give "thumb" variable a default value.

### DIFF
--- a/default.py
+++ b/default.py
@@ -207,6 +207,7 @@ def show_tv_channels():
     for station in tv_stations:
         chName = station["channel"]
         current = ""
+        thumb = False
         for d in onAirJson:
             if chName == d["channel"]:
                 current = d["currentItem"].get("name","")


### PR DESCRIPTION
Prefents errors like the following:

```
2022-07-18 20:25:48.633 T:1272050560   DEBUG: Raiplay: get Rai channels:
2022-07-18 20:25:48.784 T:1272050560   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.UnboundLocalError'>
                                            Error Contents: local variable 'thumb' referenced before assignment
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.raitv/default.py", line 771, in <module>
                                                show_tv_channels()
                                              File "/storage/.kodi/addons/plugin.video.raitv/default.py", line 218, in show_tv_channels
                                                if thumb:
                                            UnboundLocalError: local variable 'thumb' referenced before assignment
                                            -->End of Python script error report<--
```