### PR TITLE
Keep https in relinker urls

### DIFF
--- a/default.py
+++ b/default.py
@@ -175,7 +175,6 @@ def play(url, pathId="", radio_stream='0', srt=[]):
 
 
     if "relinkerServlet" in url:
-        url = url.replace ("https:", "http:")
         xbmc.log("Relinker URL: " + url)
         relinker = Relinker()
         params = relinker.getURL(url)


### PR DESCRIPTION
Relinker's requests that use http schema are failing with status 503, while https works.

Do not convert anymore https to http when building urls.
